### PR TITLE
Expose geth RPC port to host

### DIFF
--- a/scripts/quick-run/merge-devnets/docker-compose.geth.yml
+++ b/scripts/quick-run/merge-devnets/docker-compose.geth.yml
@@ -12,6 +12,8 @@ services:
   geth:
     image: parithoshj/geth:merge-893c372
     container_name: geth
+    ports:
+      - "8545:8545"
     depends_on:
       - init_geth
     volumes:


### PR DESCRIPTION
Exposes the standard RPC port to the host for connecting to it with Metamask etc.