### PR TITLE
Provided docker-compose.prysm.yml to start Prysm client

### DIFF
--- a/scripts/quick-run/merge-devnets/docker-compose.prysm.yml
+++ b/scripts/quick-run/merge-devnets/docker-compose.prysm.yml
@@ -1,0 +1,17 @@
+version: "3.4"
+services:
+  prysm_beacon:
+    image: gcr.io/prysmaticlabs/prysm/beacon-chain:kintsugi-30ed0d
+    container_name: prysm_beacon
+    volumes:
+      - ./beacon_data:/consensus_data
+      - ../../../$TESTNET_NAME/custom_config_data:/custom_config_data
+    command: >
+      --accept-terms-of-use
+      --genesis-state /custom_config_data/genesis.ssz
+      --datadir /consensus_data
+      --http-web3provider=http://localhost:8545
+      --min-sync-peers=1
+      --chain-config-file /custom_config_data/config.yaml
+      --bootstrap-node "enr:-Iq4QKuNB_wHmWon7hv5HntHiSsyE1a6cUTK1aT7xDSU_hNTLW3R4mowUboCsqYoh1kN9v3ZoSu_WuvW9Aw0tQ0Dxv6GAXxQ7Nv5gmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk"
+    network_mode: host


### PR DESCRIPTION
In this PR I would like to introduce docker compose file to start `Prysm` client as a consensus layer software. Right now I can not say more, because it is in sync phase still:

```sh
time="2021-12-30 12:25:36" level=info msg="Finished applying state transition" attestations=17 prefix=blockchain slot=19896
time="2021-12-30 12:25:36" level=info msg="Synced new block" blockRoot=0x564a4d21... epoch=621 finalizedEpoch=619 finalizedRoot=0xb51b5a68... parentRoot=0x564a4d21... prefix=blockchain slot=19897 slotInEpoch=25 version=merge
time="2021-12-30 12:25:36" level=info msg="Finished applying state transition" attestations=20 prefix=blockchain slot=19897
time="2021-12-30 12:25:36" level=info msg="Synced new block" blockRoot=0xf3bd135d... epoch=621 finalizedEpoch=619 finalizedRoot=0xb51b5a68... parentRoot=0xf3bd135d... prefix=blockchain slot=19898 slotInEpoch=26 version=merge
time="2021-12-30 12:25:36" level=info msg="Finished applying state transition" attestations=17 prefix=blockchain slot=19898
time="2021-12-30 12:25:36" level=info msg="Synced new block" blockRoot=0x18d873a1... epoch=621 finalizedEpoch=619 finalizedRoot=0xb51b5a68... parentRoot=0x18d873a1... prefix=blockchain slot=19900 slotInEpoch=28 version=merge
time="2021-12-30 12:25:36" level=info msg="Finished applying state transition" attestations=34 prefix=blockchain slot=19900
time="2021-12-30 12:25:36" level=info msg="Synced new block" blockRoot=0x1f38319e... epoch=621 finalizedEpoch=619 finalizedRoot=0xb51b5a68... parentRoot=0x1f38319e... prefix=blockchain slot=19901 slotInEpoch=29 version=merge
time="2021-12-30 12:25:36" level=info msg="Finished applying state transition" attestations=19 prefix=blockchain slot=19901
time="2021-12-30 12:25:36" level=info msg="Synced new block" blockRoot=0x94b1f421... epoch=621 finalizedEpoch=619 finalizedRoot=0xb51b5a68... parentRoot=0x94b1f421... prefix=blockchain slot=19902 slotInEpoch=30 version=merge
time="2021-12-30 12:25:36" level=info msg="Finished applying state transition" attestations=17 prefix=blockchain slot=19902
time="2021-12-30 12:25:36" level=info msg="Synced new block" blockRoot=0x248f272d... epoch=621 finalizedEpoch=619 finalizedRoot=0xb51b5a68... parentRoot=0x248f272d... prefix=blockchain slot=19903 slotInEpoch=31 version=merge
time="2021-12-30 12:25:36" level=info msg="Finished applying state transition" attestations=25 prefix=blockchain slot=19903
time="2021-12-30 12:25:36" level=info msg="Processing block batch of size 61 starting from  0xb9a26aa0... 19904/100603 - estimated time remaining 1h13m54s" blocksPerSecond=18.2 peers=45 prefix=initial-sync
```