### PR TITLE
Fix host_network port_bindings incompatibility

### DIFF
--- a/scripts/quick-run/merge-devnets/docker-compose.geth.yml
+++ b/scripts/quick-run/merge-devnets/docker-compose.geth.yml
@@ -12,8 +12,6 @@ services:
   geth:
     image: parithoshj/geth:merge-d99ac5a
     container_name: geth
-    ports:
-      - "8545:8545"
     depends_on:
       - init_geth
     volumes:


### PR DESCRIPTION
docker-compose v1.28.0 or newer doesn't allow to have both port bindings and network_mode = "host"

As network_mode="host" doesn't need any port_bindings, removed ports