### PR TITLE
fix geth startup in docker-compose

### DIFF
--- a/scripts/quick-run/merge-devnets/docker-compose.geth.yml
+++ b/scripts/quick-run/merge-devnets/docker-compose.geth.yml
@@ -12,10 +12,9 @@ services:
   geth:
     image: parithoshj/geth:merge-d99ac5a
     container_name: geth
-    ports:
-      - "8545:8545"
     depends_on:
-      - init_geth
+      init_geth:
+        condition: service_completed_successfully
     volumes:
       - ./execution_data:/execution_data
     command: >


### PR DESCRIPTION
Two things fixed in this PR:
1. As purposed ualtinok in PR #21 , removal of `network_mode="host"`
2. geth starts before geth_init has exited. Its logs says : 
` Fatal: Failed to create the protocol stack: datadir already used by another process`
Can be solved by adding a condition in the depends_on.