### PR TITLE
Use inventory_hostname to label metrics

### DIFF
--- a/playbooks/tasks/templates/prometheus/prometheus.yml.j2
+++ b/playbooks/tasks/templates/prometheus/prometheus.yml.j2
@@ -6,7 +6,7 @@ global:
   external_labels:
     consensus_client: "{{ eth2_client_name }}"
     execution_client: "{{ eth1_client_name }}"
-    instance: "{{ ansible_hostname }}"
+    instance: "{{ inventory_hostname }}"
     testnet: "{{ eth2_network_name }}"
     ip_address: "{{ ansible_host }}"
 
@@ -30,13 +30,13 @@ scrape_configs:
   - job_name: node
     static_configs:
     - labels:
-        instance: "{{ ansible_hostname }}"
+        instance: "{{ inventory_hostname }}"
       targets:
       - localhost:9100
   - job_name: beacon
     static_configs:
     - labels:
-        instance: "{{ ansible_hostname }}"
+        instance: "{{ inventory_hostname }}"
       targets:
       - localhost:{{ beacon_metrics_port }}
 
@@ -45,7 +45,7 @@ scrape_configs:
   - job_name: exporter
     static_configs:
     - labels:
-        instance: "{{ ansible_hostname }}"
+        instance: "{{ inventory_hostname }}"
       targets:
       - localhost:{{ eth_metrics_exporter_port }}
       {% endif %}
@@ -56,14 +56,14 @@ scrape_configs:
     metrics_path: /debug/metrics/prometheus
     static_configs:
     - labels:
-        instance: "{{ ansible_hostname }}"
+        instance: "{{ inventory_hostname }}"
       targets:
       - localhost:{{ eth1_metrics_port }}
 {% elif eth1_client_name == "besu" or eth1_client_name == "nethermind"  %}
   - job_name: execution_node
     static_configs:
     - labels:
-        instance: "{{ ansible_hostname }}"
+        instance: "{{ inventory_hostname }}"
       targets:
       - localhost:{{ eth1_metrics_port }}
       {% endif %}


### PR DESCRIPTION
When re-deploying a different network on the same servers, one can forget to run the setup_machine playbook again which sets the hostname. In that case the metric labels will be wrong even if re-running the metrics playbook.

Using inventory_hostname there is more intuitive.