### PR TITLE
Use inventory_hostname for paths

### DIFF
--- a/goerli-shadow-fork-2/inventory/group_vars/all.yaml
+++ b/goerli-shadow-fork-2/inventory/group_vars/all.yaml
@@ -96,8 +96,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/goerli-shadow-fork-3/inventory/group_vars/all.yaml
+++ b/goerli-shadow-fork-3/inventory/group_vars/all.yaml
@@ -101,8 +101,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/goerli-shadow-fork-4/inventory/group_vars/all.yaml
+++ b/goerli-shadow-fork-4/inventory/group_vars/all.yaml
@@ -97,8 +97,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/goerli-shadow-fork-4/inventory/group_vars/eth1client_geth.yml
+++ b/goerli-shadow-fork-4/inventory/group_vars/eth1client_geth.yml
@@ -18,7 +18,6 @@ eth1_volumes:
 geth_init_args: >
   --datadir=/eth1data init /networkdata/genesis.json
 
-
 eth1_start_args: >
   --datadir=/eth1data
   --networkid={{chainID}}
@@ -43,12 +42,11 @@ eth1_start_args: >
   {% if (eth1_bootnode_enode is defined) and eth1_bootnode_enode %}
   --bootnodes "{{ eth1_bootnode_enode | join(',') }}"
   {% endif %}
-  {% if ansible_hostname == "goerli-shadow-fork-4-eth1-bootnode-geth-1" or ansible_hostname == "goerli-shadow-fork-4-lighthouse-geth-1" or ansible_hostname == "goerli-shadow-fork-4-teku-geth-1"  %}
+  {% if inventory_hostname == "goerli-shadow-fork-4-eth1-bootnode-geth-1" or inventory_hostname == "goerli-shadow-fork-4-lighthouse-geth-1" or inventory_hostname == "goerli-shadow-fork-4-teku-geth-1"  %}
   --gcmode=archive
   {% endif %}
 
 eth1_user_id: "1000:1000"
-
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork init genesis.json
 # ./go-ethereum/build/bin/geth --authrpc.jwtsecret=/home/devops/jwtsecret --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash --mine --miner.threads=1 --miner.etherbase=0xfb969eb20eca70c2800103bbb0d3757bc60f918a --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.api="engine,net,eth,debug,txpool"  --nat extip:164.90.177.4 --networkid=5 console
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash  --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.vhosts="*" --http.api="engine,net,eth,debug,txpool" --ws --ws.api="eth,net,engine" --ws.port=8546 --ws.addr="0.0.0.0" --rpc.allow-unprotected-txs  --nat extip:164.90.177.4 --networkid=5 console

--- a/goerli-shadow-fork/inventory/group_vars/all.yaml
+++ b/goerli-shadow-fork/inventory/group_vars/all.yaml
@@ -88,8 +88,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/kiln-testnet/inventory/group_vars/all.yaml
+++ b/kiln-testnet/inventory/group_vars/all.yaml
@@ -96,8 +96,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/kintsugi-testnet/inventory/group_vars/all.yaml
+++ b/kintsugi-testnet/inventory/group_vars/all.yaml
@@ -94,8 +94,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/mainnet-shadow-fork-1/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-1/inventory/group_vars/all.yaml
@@ -100,8 +100,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/mainnet-shadow-fork-1/inventory/group_vars/eth1client_besu.yml
+++ b/mainnet-shadow-fork-1/inventory/group_vars/eth1client_besu.yml
@@ -2,7 +2,7 @@ eth1_client_name: besu
 eth1_image_name: hyperledger/besu:22.4.0-RC2-SNAPSHOT
 execution_endpoint: http://127.0.0.1:{{eth1_engine_snoop_port}}
 
-home_dir: /mnt/volume_{{ ansible_hostname  | replace('-','_') }}
+home_dir: /mnt/volume_{{ inventory_hostname  | replace('-','_') }}
 
 eth1_memory: 5000M
 eth1_kernel_memory: 5500M

--- a/mainnet-shadow-fork-1/inventory/group_vars/eth1client_geth.yml
+++ b/mainnet-shadow-fork-1/inventory/group_vars/eth1client_geth.yml
@@ -2,7 +2,7 @@ eth1_client_name: geth
 eth1_image_name: parithoshj/geth:ttd-override-flag-87a9773
 execution_endpoint: http://127.0.0.1:{{eth1_engine_snoop_port}}
 
-home_dir: /mnt/volume_{{ ansible_hostname  | replace('-','_') }}
+home_dir: /mnt/volume_{{ inventory_hostname  | replace('-','_') }}
 
 eth1_github_external_user_pubkeys:
   - mariusVanDerWijden
@@ -17,7 +17,6 @@ eth1_volumes:
 
 geth_init_args: >
   --datadir=/eth1data init /networkdata/genesis.json
-
 
 eth1_start_args: >
   --datadir=/eth1data
@@ -43,12 +42,11 @@ eth1_start_args: >
   {% if (eth1_bootnode_enode is defined) and eth1_bootnode_enode %}
   --bootnodes "{{ eth1_bootnode_enode | join(',') }}"
   {% endif %}
-  {% if ansible_hostname == "mainnet-shadow-fork-1-eth1-bootnode-geth-1" or ansible_hostname == "mainnet-shadow-fork-1-lighthouse-geth-1" or ansible_hostname == "mainnet-shadow-fork-1-teku-geth-1"  %}
+  {% if inventory_hostname == "mainnet-shadow-fork-1-eth1-bootnode-geth-1" or inventory_hostname == "mainnet-shadow-fork-1-lighthouse-geth-1" or inventory_hostname == "mainnet-shadow-fork-1-teku-geth-1"  %}
   --gcmode=archive
   {% endif %}
 
 eth1_user_id: "1000:1000"
-
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork init genesis.json
 # ./go-ethereum/build/bin/geth --authrpc.jwtsecret=/home/devops/jwtsecret --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash --mine --miner.threads=1 --miner.etherbase=0xfb969eb20eca70c2800103bbb0d3757bc60f918a --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.api="engine,net,eth,debug,txpool"  --nat extip:164.90.177.4 --networkid=5 console
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash  --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.vhosts="*" --http.api="engine,net,eth,debug,txpool" --ws --ws.api="eth,net,engine" --ws.port=8546 --ws.addr="0.0.0.0" --rpc.allow-unprotected-txs  --nat extip:164.90.177.4 --networkid=5 console

--- a/mainnet-shadow-fork-2/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-2/inventory/group_vars/all.yaml
@@ -109,8 +109,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/mainnet-shadow-fork-2/inventory/group_vars/eth1client_geth.yml
+++ b/mainnet-shadow-fork-2/inventory/group_vars/eth1client_geth.yml
@@ -18,7 +18,6 @@ eth1_volumes:
 geth_init_args: >
   --datadir=/eth1data init /networkdata/genesis.json
 
-
 eth1_start_args: >
   --datadir=/eth1data
   --networkid={{chainID}}
@@ -43,12 +42,11 @@ eth1_start_args: >
   {% if (eth1_bootnode_enode is defined) and eth1_bootnode_enode %}
   --bootnodes "{{ eth1_bootnode_enode | join(',') }}"
   {% endif %}
-  {% if ansible_hostname == "mainnet-shadow-fork-2-eth1-bootnode-geth-1" or ansible_hostname == "mainnet-shadow-fork-2-lighthouse-geth-1" or ansible_hostname == "mainnet-shadow-fork-2-teku-geth-1"  %}
+  {% if inventory_hostname == "mainnet-shadow-fork-2-eth1-bootnode-geth-1" or inventory_hostname == "mainnet-shadow-fork-2-lighthouse-geth-1" or inventory_hostname == "mainnet-shadow-fork-2-teku-geth-1"  %}
   --gcmode=archive
   {% endif %}
 
 eth1_user_id: "1000:1000"
-
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork init genesis.json
 # ./go-ethereum/build/bin/geth --authrpc.jwtsecret=/home/devops/jwtsecret --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash --mine --miner.threads=1 --miner.etherbase=0xfb969eb20eca70c2800103bbb0d3757bc60f918a --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.api="engine,net,eth,debug,txpool"  --nat extip:164.90.177.4 --networkid=5 console
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash  --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.vhosts="*" --http.api="engine,net,eth,debug,txpool" --ws --ws.api="eth,net,engine" --ws.port=8546 --ws.addr="0.0.0.0" --rpc.allow-unprotected-txs  --nat extip:164.90.177.4 --networkid=5 console

--- a/mainnet-shadow-fork-3/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-3/inventory/group_vars/all.yaml
@@ -108,8 +108,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/mainnet-shadow-fork-3/inventory/group_vars/eth1client_geth.yml
+++ b/mainnet-shadow-fork-3/inventory/group_vars/eth1client_geth.yml
@@ -18,7 +18,6 @@ eth1_volumes:
 geth_init_args: >
   --datadir=/eth1data init /networkdata/genesis.json
 
-
 eth1_start_args: >
   --datadir=/eth1data
   --networkid={{chainID}}
@@ -43,12 +42,11 @@ eth1_start_args: >
   {% if (eth1_bootnode_enode is defined) and eth1_bootnode_enode %}
   --bootnodes "{{ eth1_bootnode_enode | join(',') }}"
   {% endif %}
-  {% if ansible_hostname == "mainnet-shadow-fork-3-eth1-bootnode-geth-1" or ansible_hostname == "mainnet-shadow-fork-3-lighthouse-geth-1" or ansible_hostname == "mainnet-shadow-fork-3-teku-geth-1"  %}
+  {% if inventory_hostname == "mainnet-shadow-fork-3-eth1-bootnode-geth-1" or inventory_hostname == "mainnet-shadow-fork-3-lighthouse-geth-1" or inventory_hostname == "mainnet-shadow-fork-3-teku-geth-1"  %}
   --gcmode=archive
   {% endif %}
 
 eth1_user_id: "1000:1000"
-
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork init genesis.json
 # ./go-ethereum/build/bin/geth --authrpc.jwtsecret=/home/devops/jwtsecret --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash --mine --miner.threads=1 --miner.etherbase=0xfb969eb20eca70c2800103bbb0d3757bc60f918a --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.api="engine,net,eth,debug,txpool"  --nat extip:164.90.177.4 --networkid=5 console
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash  --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.vhosts="*" --http.api="engine,net,eth,debug,txpool" --ws --ws.api="eth,net,engine" --ws.port=8546 --ws.addr="0.0.0.0" --rpc.allow-unprotected-txs  --nat extip:164.90.177.4 --networkid=5 console

--- a/mainnet-shadow-fork-4/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-4/inventory/group_vars/all.yaml
@@ -109,8 +109,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/mainnet-shadow-fork-4/inventory/group_vars/eth1client_geth.yml
+++ b/mainnet-shadow-fork-4/inventory/group_vars/eth1client_geth.yml
@@ -18,7 +18,6 @@ eth1_volumes:
 geth_init_args: >
   --datadir=/eth1data init /networkdata/genesis.json
 
-
 eth1_start_args: >
   --datadir=/eth1data
   --networkid={{chainID}}
@@ -43,12 +42,11 @@ eth1_start_args: >
   {% if (eth1_bootnode_enode is defined) and eth1_bootnode_enode %}
   --bootnodes "{{ eth1_bootnode_enode | join(',') }}"
   {% endif %}
-  {% if ansible_hostname == "mainnet-shadow-fork-4-eth1-bootnode-geth-1" or ansible_hostname == "mainnet-shadow-fork-4-lighthouse-geth-1" or ansible_hostname == "mainnet-shadow-fork-4-teku-geth-1"  %}
+  {% if inventory_hostname == "mainnet-shadow-fork-4-eth1-bootnode-geth-1" or inventory_hostname == "mainnet-shadow-fork-4-lighthouse-geth-1" or inventory_hostname == "mainnet-shadow-fork-4-teku-geth-1"  %}
   --gcmode=archive
   {% endif %}
 
 eth1_user_id: "1000:1000"
-
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork init genesis.json
 # ./go-ethereum/build/bin/geth --authrpc.jwtsecret=/home/devops/jwtsecret --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash --mine --miner.threads=1 --miner.etherbase=0xfb969eb20eca70c2800103bbb0d3757bc60f918a --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.api="engine,net,eth,debug,txpool"  --nat extip:164.90.177.4 --networkid=5 console
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash  --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.vhosts="*" --http.api="engine,net,eth,debug,txpool" --ws --ws.api="eth,net,engine" --ws.port=8546 --ws.addr="0.0.0.0" --rpc.allow-unprotected-txs  --nat extip:164.90.177.4 --networkid=5 console

--- a/mainnet-shadow-fork-5/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-5/inventory/group_vars/all.yaml
@@ -109,8 +109,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/mainnet-shadow-fork-5/inventory/group_vars/eth1client_geth.yml
+++ b/mainnet-shadow-fork-5/inventory/group_vars/eth1client_geth.yml
@@ -19,7 +19,6 @@ eth1_volumes:
 geth_init_args: >
   --datadir=/eth1data init /networkdata/genesis.json
 
-
 eth1_start_args: >
   --datadir=/eth1data
   --networkid={{chainID}}
@@ -44,12 +43,11 @@ eth1_start_args: >
   {% if (eth1_bootnode_enode is defined) and eth1_bootnode_enode %}
   --bootnodes "{{ eth1_bootnode_enode | join(',') }}"
   {% endif %}
-  {% if ansible_hostname == "mainnet-shadow-fork-5-eth1-bootnode-geth-1" or ansible_hostname == "mainnet-shadow-fork-5-lighthouse-geth-1" or ansible_hostname == "mainnet-shadow-fork-5-teku-geth-1"  %}
+  {% if inventory_hostname == "mainnet-shadow-fork-5-eth1-bootnode-geth-1" or inventory_hostname == "mainnet-shadow-fork-5-lighthouse-geth-1" or inventory_hostname == "mainnet-shadow-fork-5-teku-geth-1"  %}
   --gcmode=archive
   {% endif %}
 
 eth1_user_id: "1000:1000"
-
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork init genesis.json
 # ./go-ethereum/build/bin/geth --authrpc.jwtsecret=/home/devops/jwtsecret --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash --mine --miner.threads=1 --miner.etherbase=0xfb969eb20eca70c2800103bbb0d3757bc60f918a --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.api="engine,net,eth,debug,txpool"  --nat extip:164.90.177.4 --networkid=5 console
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash  --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.vhosts="*" --http.api="engine,net,eth,debug,txpool" --ws --ws.api="eth,net,engine" --ws.port=8546 --ws.addr="0.0.0.0" --rpc.allow-unprotected-txs  --nat extip:164.90.177.4 --networkid=5 console

--- a/mainnet-shadow-fork-6/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-6/inventory/group_vars/all.yaml
@@ -111,8 +111,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/mainnet-shadow-fork-6/inventory/group_vars/eth1client_geth.yml
+++ b/mainnet-shadow-fork-6/inventory/group_vars/eth1client_geth.yml
@@ -19,7 +19,6 @@ eth1_volumes:
 geth_init_args: >
   --datadir=/eth1data init /networkdata/genesis.json
 
-
 eth1_start_args: >
   --datadir=/eth1data
   --networkid={{chainID}}
@@ -44,12 +43,11 @@ eth1_start_args: >
   {% if (eth1_bootnode_enode is defined) and eth1_bootnode_enode %}
   --bootnodes "{{ eth1_bootnode_enode | join(',') }}"
   {% endif %}
-  {% if ansible_hostname == "mainnet-shadow-fork-6-eth1-bootnode-geth-1" or ansible_hostname == "mainnet-shadow-fork-6-lighthouse-geth-1" or ansible_hostname == "mainnet-shadow-fork-6-teku-geth-1"  %}
+  {% if inventory_hostname == "mainnet-shadow-fork-6-eth1-bootnode-geth-1" or inventory_hostname == "mainnet-shadow-fork-6-lighthouse-geth-1" or inventory_hostname == "mainnet-shadow-fork-6-teku-geth-1"  %}
   --gcmode=archive
   {% endif %}
 
 eth1_user_id: "1000:1000"
-
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork init genesis.json
 # ./go-ethereum/build/bin/geth --authrpc.jwtsecret=/home/devops/jwtsecret --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash --mine --miner.threads=1 --miner.etherbase=0xfb969eb20eca70c2800103bbb0d3757bc60f918a --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.api="engine,net,eth,debug,txpool"  --nat extip:164.90.177.4 --networkid=5 console
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash  --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.vhosts="*" --http.api="engine,net,eth,debug,txpool" --ws --ws.api="eth,net,engine" --ws.port=8546 --ws.addr="0.0.0.0" --rpc.allow-unprotected-txs  --nat extip:164.90.177.4 --networkid=5 console

--- a/mainnet-shadow-fork-7/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-7/inventory/group_vars/all.yaml
@@ -116,8 +116,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/mainnet-shadow-fork-7/inventory/group_vars/eth1client_geth.yml
+++ b/mainnet-shadow-fork-7/inventory/group_vars/eth1client_geth.yml
@@ -19,7 +19,6 @@ eth1_volumes:
 geth_init_args: >
   --datadir=/eth1data init /networkdata/genesis.json
 
-
 eth1_start_args: >
   --datadir=/eth1data
   --networkid={{chainID}}
@@ -44,12 +43,11 @@ eth1_start_args: >
   {% if (eth1_bootnode_enode is defined) and eth1_bootnode_enode %}
   --bootnodes "{{ eth1_bootnode_enode | join(',') }}"
   {% endif %}
-  {% if ansible_hostname == "mainnet-shadow-fork-7-eth1-bootnode-geth-1" or ansible_hostname == "mainnet-shadow-fork-7-lighthouse-geth-1" or ansible_hostname == "mainnet-shadow-fork-7-teku-geth-1"  %}
+  {% if inventory_hostname == "mainnet-shadow-fork-7-eth1-bootnode-geth-1" or inventory_hostname == "mainnet-shadow-fork-7-lighthouse-geth-1" or inventory_hostname == "mainnet-shadow-fork-7-teku-geth-1"  %}
   --gcmode=archive
   {% endif %}
 
 eth1_user_id: "1000:1000"
-
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork init genesis.json
 # ./go-ethereum/build/bin/geth --authrpc.jwtsecret=/home/devops/jwtsecret --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash --mine --miner.threads=1 --miner.etherbase=0xfb969eb20eca70c2800103bbb0d3757bc60f918a --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.api="engine,net,eth,debug,txpool"  --nat extip:164.90.177.4 --networkid=5 console
 # ./go-ethereum/build/bin/geth --datadir=./goerli-shadow-fork --ethash.dagdir=./goerli-shadow-fork/ethash  --http --http.corsdomain='*' --http.addr="0.0.0.0" --http.vhosts="*" --http.api="engine,net,eth,debug,txpool" --ws --ws.api="eth,net,engine" --ws.port=8546 --ws.addr="0.0.0.0" --rpc.allow-unprotected-txs  --nat extip:164.90.177.4 --networkid=5 console

--- a/merge-devnet-0/inventory/group_vars/all.yaml
+++ b/merge-devnet-0/inventory/group_vars/all.yaml
@@ -82,8 +82,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/merge-devnet-1/inventory/group_vars/all.yaml
+++ b/merge-devnet-1/inventory/group_vars/all.yaml
@@ -84,8 +84,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/merge-devnet-2/inventory/group_vars/all.yaml
+++ b/merge-devnet-2/inventory/group_vars/all.yaml
@@ -83,8 +83,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/merge-devnet-3/inventory/group_vars/all.yaml
+++ b/merge-devnet-3/inventory/group_vars/all.yaml
@@ -83,8 +83,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/merge-devnet-4/inventory/group_vars/all.yaml
+++ b/merge-devnet-4/inventory/group_vars/all.yaml
@@ -88,8 +88,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/merge-devnet-5/inventory/group_vars/all.yaml
+++ b/merge-devnet-5/inventory/group_vars/all.yaml
@@ -92,8 +92,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/pithos-testnet/inventory/group_vars/all.yaml
+++ b/pithos-testnet/inventory/group_vars/all.yaml
@@ -81,8 +81,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories

--- a/sync-test/inventory/group_vars/all.yaml
+++ b/sync-test/inventory/group_vars/all.yaml
@@ -100,8 +100,8 @@ local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
 # private dirs
 # Validator assignments
-local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"
-local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}.tar.gz"
+local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}"
+local_validator_host_archive: "{{inventory_dir}}/../validator_prep/{{inventory_hostname}}.tar.gz"
 
 ##############################################
 # remote host data directories


### PR DESCRIPTION
When re-deploying a different network on the same servers, one can forget to run the setup_machine playbook again which sets the hostname.

Similar to https://github.com/parithosh/consensus-deployment-ansible/pull/44 but split in a second PR since here the diff is bigger.