### PR TITLE
Don't recreate JWT file if exists

### DIFF
--- a/playbooks/tasks/mkdatadirs.yml
+++ b/playbooks/tasks/mkdatadirs.yml
@@ -34,10 +34,16 @@
       file:
         path: "{{testnet_dir}}"
         state: directory
+
 - name: Init JWT secret
   hosts: [beacon, execution]
   gather_facts: false
   serial: 20
   tasks:
+    - name: Stat JWT path
+      register: jwt_path_stat
+      stat:
+        path: "{{ home_dir }}/jwtsecret"
     - name: Creates JWT secret
+      when: not jwt_path_stat.stat.exists
       shell: echo -n 0x$(openssl rand -hex 32 | tr -d "\n") > "{{ home_dir }}/jwtsecret"


### PR DESCRIPTION
Prevent re-creating the JWT file involuntarily.

IMO the JWT file should also be created in a pre-step to start_beacon_node or start_beacon_execution.