### PR TITLE
Move setup_hostname to separate playbook

### DIFF
--- a/playbooks/tasks/setup_hostname.yml
+++ b/playbooks/tasks/setup_hostname.yml
@@ -1,0 +1,12 @@
+- name: set hostname
+  hosts: all
+  become: true
+  tasks:
+    - name: Set hostname
+      hostname:
+        name: "{{ inventory_hostname }}"
+    - name: add myself to /etc/hosts
+      lineinfile:
+        dest: /etc/hosts
+        regexp: "^{{ ansible_host }}="
+        line: "{{ ansible_host }} {{ inventory_hostname }}"

--- a/playbooks/tasks/setup_machine.yml
+++ b/playbooks/tasks/setup_machine.yml
@@ -14,19 +14,7 @@
     - role: robertdebock.bootstrap
       tags: [bootstrap]
 
-
-- name: set hostname
-  hosts: all
-  become: true
-  tasks:
-    - name: Set hostname
-      hostname:
-        name: "{{ inventory_hostname }}"
-    - name: add myself to /etc/hosts
-      lineinfile:
-        dest: /etc/hosts
-        regexp: '^{{ ansible_host }}='
-        line: '{{ ansible_host }} {{ inventory_hostname }}'
+- import_playbook: setup_hostname.yml
 
 - name: Setup general tools used and update system
   hosts:


### PR DESCRIPTION
Allow to only setup_hostname on already setup machines.

This is useful when re-using existing hosts for another network. 

Related:
- https://github.com/parithosh/consensus-deployment-ansible/pull/44
- https://github.com/parithosh/consensus-deployment-ansible/pull/45