### PR TITLE
Add bootstrap_user to docker group

### DIFF
--- a/playbooks/tasks/setup_machine.yml
+++ b/playbooks/tasks/setup_machine.yml
@@ -59,7 +59,9 @@
             name: python3-docker
             state: present
         - name: Add ansible user to docker group
-          shell: 'usermod -aG docker {{ ansible_user }}'
+          shell: "usermod -aG docker {{ ansible_user }}"
+        - name: Add bootstrap user to docker group
+          shell: "usermod -aG docker {{ bootstrap_user }}"
     - name: Reload service docker, in all cases
       ansible.builtin.service:
         name: docker


### PR DESCRIPTION
When running the setup playbooks on a fresh machine, ansible_user is still root. Then the actual user devops used in the rest of runs won't be in the docker group.

So add both ansible_user and bootstrap_user to docker group