### PR TITLE
Create beacon_node_dir before starting container

### DIFF
--- a/playbooks/tasks/start_beacon.yml
+++ b/playbooks/tasks/start_beacon.yml
@@ -3,6 +3,10 @@
   gather_facts: true
   serial: 20
   tasks:
+    - name: Creates beacon dir
+      file:
+        path: "{{beacon_node_dir}}"
+        state: directory
     - name: Modify permissions to match user-group inside docker image
       shell: chown -R "{{ beacon_user_id }}" "{{ beacon_node_dir }}"
       become: true


### PR DESCRIPTION
If you always run all playbooks in a precise sequence, this PR should not be necessary.

However, for me it is a big UX plus as when debugging deployments and re-deploying quickly I had to spent time running mkdatadirs again just for this directory.