### PR TITLE
Add collect_enrs playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ faucet.yml
 reverse_proxy.yml
 dshackle.yml
 .vscode/settings.json
+enrs.json
 

--- a/playbooks/tasks/collect_enrs.yml
+++ b/playbooks/tasks/collect_enrs.yml
@@ -1,0 +1,23 @@
+- name: Collect ENRs
+  hosts: beacon
+  gather_facts: false
+  serial: 20
+  tasks:
+    - name: Get node identity
+      shell: curl http://localhost:{{beacon_api_port}}/eth/v1/node/identity
+      register: node_identity_response
+    - name: Set each node's own enode
+      set_fact:
+        beacon_enr: "{{( node_identity_response.stdout | from_json)['data']['enr'] }}"
+- name: Write ENRs
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Create a map with all node's ENRs
+      with_items: "{{ groups['beacon'] }}"
+      set_fact:
+        beacon_enrs: "{{ beacon_enrs|default({}) | combine( {item: hostvars[item]['beacon_enr']} ) }}"
+    - name: Write ENRs
+      copy:
+        content: "{{ beacon_enrs.values() | list | to_nice_json }}"
+        dest: "../../enrs.json"


### PR DESCRIPTION
Collects ENRs and writes them to a file in the root, `enrs.json`

```json
[
  "enr:-Iq4QMCTfIMXnow27baRUb35Q8iiFHSIDBJh6hQM5Axohhf4b6Kr_cOCu0htQ5WvVqKvFgY28893DHAg8gnBAXsAVqmGAX53x8JggmlkgnY0gmlwhLKAlv6Jc2VjcDI1NmsxoQK6S-Cii_KmfFdUJL2TANL3ksaKUnNXvTCv1tLwXs0QgIN1ZHCCIyk"
  "enr:-Ly4QGWGgf2vlWRRV1nrRHvwRWYRYJYnijCjCFpCxodG8nWYTRksaTSixPEhLjmoC4ivmWGkbmPpC0H4Uyy5b4z8VaYBh2F0dG5ldHOIAAAAAAAAAACEZXRoMpCEfltAIQAQMDIAAAAAAAAAgmlkgnY0gmlwhJK-Gc-Jc2VjcDI1NmsxoQN856T24INJcQ8GJpE0BdSMAMEmqZnLp7kyapS9Ekaq3ohzeW5jbmV0cwCDdGNwgiMog3VkcIIjKA"
]
```

You can then copy the contents and paste as-is in `bootnode_enrs:` since YAML supports JSON syntax.

Very convenient to grab the ENRs of bootnodes or any group, since it leverages `-f` ansible functionality