### PR TITLE
Enable setup_node_exporter_and_prometheus playbook

### DIFF
--- a/playbooks/setup_execution_and_consensus_full.yml
+++ b/playbooks/setup_execution_and_consensus_full.yml
@@ -18,7 +18,7 @@
 # uploads custom chain config and genesis data if needed
 - import_playbook: tasks/upload_custom_config_data.yml
   when: (testnet_type == 'custom') or
-        (testnet_type == 'prater' and eth2_client_name == 'prysm')
+    (testnet_type == 'prater' and eth2_client_name == 'prysm')
 
 # inits geth instance
 - import_playbook: tasks/init_geth_node.yml
@@ -39,5 +39,5 @@
   when: separate_validator_process_enabled
 
 # install node_exporter and metric pusher
-# - import_playbook: tasks/setup_node_exporter_and_prometheus.yml
-#   when: push_metrics_enabled
+- import_playbook: tasks/setup_node_exporter_and_prometheus.yml
+  when: push_metrics_enabled

--- a/playbooks/tasks/setup_node_exporter_and_prometheus.yml
+++ b/playbooks/tasks/setup_node_exporter_and_prometheus.yml
@@ -1,12 +1,15 @@
 - name: Start node exporter and prometheus
-  hosts: beacon, validator
+  hosts: beacon, validator, execution
   gather_facts: true
   roles:
     - cloudalchemy.node-exporter
     - cloudalchemy.prometheus
   tasks:
     - name: Start exporter container
-      when: eth_metrics_exporter_enabled | bool
+      when:
+        - eth_metrics_exporter_enabled | bool
+        - eth2_client_name is defined
+        - eth1_client_name is defined
       docker_container:
         name: "{{ eth_metrics_exporter_name }}"
         state: started


### PR DESCRIPTION
@parithosh is there any specific reason to disable this playbook?

Without it there are no metrics, so it's critical for a generic deployment.