### PR TITLE
Add collect_enodes playbook

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,4 +20,5 @@ faucet.yml
 reverse_proxy.yml
 dshackle.yml
 .vscode/settings.json
+enodes.json
 

--- a/playbooks/tasks/collect_enodes.yml
+++ b/playbooks/tasks/collect_enodes.yml
@@ -1,0 +1,23 @@
+- name: Collect enodes
+  hosts: execution
+  gather_facts: false
+  serial: 20
+  tasks:
+    - name: Get enode from logs
+      shell: docker logs {{execution_container_name}} | grep enode:// | sed 's/.*enode:\/\///'
+      register: enode_noprefix_cmd
+    - name: Set each node's own enode
+      set_fact:
+        execution_enode: "enode://{{enode_noprefix_cmd.stdout}}"
+- name: Write enodes
+  hosts: localhost
+  gather_facts: true
+  tasks:
+    - name: Create a map with all node's enodes
+      with_items: "{{ groups['execution'] }}"
+      set_fact:
+        execution_enodes: "{{ execution_enodes|default({}) | combine( {item: hostvars[item]['execution_enode']} ) }}"
+    - name: Write enodes
+      copy:
+        content: "{{ execution_enodes.values() | list | to_nice_json }}"
+        dest: "../../enodes.json"


### PR DESCRIPTION
Similar to https://github.com/parithosh/consensus-deployment-ansible/pull/55

Collects enodes and writes them to a file in the root, `enodes.json`

```json
[
  "enode://37f1929c49100ad8c4dd4155abc798de59307f3289d8a88a16b3d20320cf291a7ed2576d2f4c9e488be5bd6bb6c08ad39994f254aba50c53923427ca0af5d813@146.190.25.207:30303"
  "enode://683fc52a836fe75236cd69c48ff5d86fde2408fc38c270e21a749a86921363fce569bcd9ae40d39c8caa8edf24a07512f755d90e4d500f49dea6cfe8bc9fdd9d@167.71.90.58:30303"
]
```

You can then copy the contents and paste as-is in `eth1_bootnode_enode:` since YAML supports JSON syntax.

Very convenient to grab those of any group, since it leverages `-f` ansible functionality

**Note**: Not as robust as https://github.com/parithosh/consensus-deployment-ansible/pull/55 since it grabs from logs but so far has not broke for me. Not sure if ELs have an API to programmatically grab the enode, @parithosh ?