### PR TITLE
Use execution_container_name instead of client name

### DIFF
--- a/mainnet-shadow-fork-7/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-7/inventory/group_vars/all.yaml
@@ -143,6 +143,7 @@ common_log_driver: json-file
 ##############################################
 beacon_container_name: beacon
 validator_container_name: validator
+execution_container_name: execution
 hi_peer_count: 100
 separate_validator_process_enabled: true
 

--- a/playbooks/stop_all.yml
+++ b/playbooks/stop_all.yml
@@ -13,6 +13,6 @@
       register: stop_result
       failed_when: "(stop_result.rc >= 1) and not ('No such container' in stop_result.stderr)"
     - name: Stop geth client container
-      shell: "docker stop --time=10 {{eth1_client_name}}"
+      shell: "docker stop --time=10 {{execution_container_name}}"
       register: stop_result
       failed_when: "(stop_result.rc >= 1) and not ('No such container' in stop_result.stderr)"

--- a/playbooks/tasks/start_execution_node.yml
+++ b/playbooks/tasks/start_execution_node.yml
@@ -5,7 +5,7 @@
   tasks:
     - name: Start execution node container
       docker_container:
-        name: "{{ eth1_client_name }}"
+        name: "{{ execution_container_name }}"
         state: started
         image: "{{ eth1_image_name }}"
         pull: true

--- a/playbooks/tasks/stop_execution_node.yml
+++ b/playbooks/tasks/stop_execution_node.yml
@@ -4,6 +4,6 @@
   serial: 20
   tasks:
     - name: Stop execution node container
-      shell: "docker stop {{ eth1_client_name }}"
+      shell: "docker stop {{ execution_container_name }}"
       register: stop_result
       failed_when: "(stop_result.rc >= 1) and not ('No such container' in stop_result.stderr)"

--- a/playbooks/wipe_all.yml
+++ b/playbooks/wipe_all.yml
@@ -23,7 +23,7 @@
         path: "{{validator_node_dir}}"
         state: absent
     - name: Stop execution client container
-      shell: "docker stop {{eth1_client_name}}"
+      shell: "docker stop {{execution_container_name}}"
       register: stop_result
       failed_when: "(stop_result.rc >= 1) and not ('No such container' in stop_result.stderr)"
     - name: Remove execution data
@@ -34,7 +34,7 @@
     - name: Remove testnet dir
       become: true
       when: (testnet_type == 'custom') or
-            (testnet_type == 'prater' and eth2_client_name == 'prysm')
+        (testnet_type == 'prater' and eth2_client_name == 'prysm')
       file:
         path: "{{testnet_dir}}"
         state: absent


### PR DESCRIPTION
Consensus containers are named generically `beacon` and `validator`. Execution containers should be named generically too.

@parithosh is there a reason I'm missing?

Note: If this PR is not merged, change https://github.com/parithosh/consensus-deployment-ansible/pull/60 to user eth1_client_name