### PR TITLE
Update cloudalchemy.node-exporter name

### DIFF
--- a/playbooks/tasks/deploy_node_exporter_and_metric_pusher.yml
+++ b/playbooks/tasks/deploy_node_exporter_and_metric_pusher.yml
@@ -2,14 +2,14 @@
   hosts: beacon, validator
   gather_facts: true
   roles:
-    - cloudalchemy.node-exporter
+    - cloudalchemy.node_exporter
   tasks:
     - name: Move the j2 template to remote
       become: true
       template:
         src: ../templates/metric-pusher.sh
         dest: /opt/metric-pusher.sh
-        mode: '755'
+        mode: "755"
 
     - name: Enable cronjob to push metrics to the prometheus pushgateway
       cron:

--- a/playbooks/tasks/setup_node_exporter_and_prometheus.yml
+++ b/playbooks/tasks/setup_node_exporter_and_prometheus.yml
@@ -2,7 +2,7 @@
   hosts: beacon, validator, execution
   gather_facts: true
   roles:
-    - cloudalchemy.node-exporter
+    - cloudalchemy.node_exporter
     - cloudalchemy.prometheus
   tasks:
     - name: Start exporter container


### PR DESCRIPTION
Now that roles are pulled from ansible galaxy there's a discrepancy with cloudalchemy.node-exporter role name. When installed from galaxy it's actually named `cloudalchemy.node_exporter`.

See https://galaxy.ansible.com/cloudalchemy/node_exporter