### PR TITLE
Use regular secrets directory for lodestar

### DIFF
--- a/playbooks/tasks/upload_validator_keys.yml
+++ b/playbooks/tasks/upload_validator_keys.yml
@@ -51,7 +51,7 @@
       delegate_to: localhost
       shell: |
         cp -r "{{local_validator_host_dir}}/keys" "{{local_validator_host_dir}}/selected_keys/keystores"
-        cp -r "{{local_validator_host_dir}}/lodestar-secrets" "{{local_validator_host_dir}}/selected_keys/secrets"
+        cp -r "{{local_validator_host_dir}}/secrets" "{{local_validator_host_dir}}/selected_keys/secrets"
     - name: Archive validator dir to prepare for upload
       when: not does_key_tar_exist.stat.exists
       delegate_to: localhost


### PR DESCRIPTION
In legacy version of Lodestar

> The secrets dir has pubkey-named files containing passwords, but the pubkey in the names are encoded without the 0x prefix. The validators-DB dir is unimportant, and can be left empty. This is managed by lodestar.

This is an old bug that has been patched for a while. To drop this legacy code that reads the password from either 0x prefixed or not named files this tool should be updated.

Lodestar can use the exact same logic as Lighthouse or 0x prefix the secret key filename