### PR TITLE
Add generate_eth2_genesis_and_keys

### DIFF
--- a/mainnet-shadow-fork-8/inventory/group_vars/all.yaml
+++ b/mainnet-shadow-fork-8/inventory/group_vars/all.yaml
@@ -107,6 +107,8 @@ local_forkmondata_host_dir: "{{inventory_dir}}/../forkmondata"
 local_forkmondata_host_archive: "{{inventory_dir}}/../forkmondata.tar.gz"
 local_custom_config_data_host_dir: "{{inventory_dir}}/../custom_config_data"
 local_custom_config_data_host_archive: "{{inventory_dir}}/../custom_config_data.tar.gz"
+local_eth2_config_filepath: "{{local_custom_config_data_host_dir}}/config.yaml"
+local_mnemonics_filepath: "{{local_custom_config_data_host_dir}}/mnemonics.yaml"
 # private dirs
 # Validator assignments
 local_validator_host_dir: "{{inventory_dir}}/../validator_prep/{{ansible_hostname}}"

--- a/playbooks/tasks/generate_eth2_genesis_and_keys.yml
+++ b/playbooks/tasks/generate_eth2_genesis_and_keys.yml
@@ -1,0 +1,98 @@
+- name: Generate eth2 genesis
+  hosts: validator
+  gather_facts: false
+  tasks:
+    - name: Grab validator keys data
+      delegate_to: localhost
+      run_once: true
+      with_items: "{{ groups['validator'] }}"
+      set_fact:
+        keys_data_dict: "{{ keys_data_dict|default({}) | combine( {item: {'indexes': hostvars[item]['indexes'], 'mnemonic': hostvars[item]['mnemonic']}} ) }}"
+
+    - name: Validate ranges + prepare mnemonics.yaml
+      delegate_to: localhost
+      run_once: true
+      script: "./scripts/validate_eth2_indexes.py '{{keys_data_dict | to_json}}' {{local_eth2_config_filepath}} {{local_mnemonics_filepath}}"
+
+    - name: Load config
+      delegate_to: localhost
+      run_once: true
+      set_fact:
+        eth2_config: "{{ lookup('file', local_eth2_config_filepath) | from_yaml }}"
+
+    # Note the genesis time persisted in genesis.ssz = MIN_GENESIS_TIME + GENESIS_DELAY
+    - name: Generate genesis
+      delegate_to: localhost
+      run_once: true
+      vars:
+        cl_genesis_eth1_block: "0x0000000000000000000000000000000000000000000000000000000000000000"
+      shell: >
+        docker run --rm --entrypoint=eth2-testnet-genesis \
+        -v {{local_custom_config_data_host_dir}}:/data \
+        skylenet/ethereum-genesis-generator phase0 \
+        --eth1-block "{{cl_genesis_eth1_block}}" \
+        --timestamp "{{eth2_config['MIN_GENESIS_TIME']}}" \
+        --config /data/config.yaml \
+        --mnemonics /data/mnemonics.yaml \
+        --tranches-dir /data/tranches \
+        --state-output /data/genesis.ssz
+- name: Generate validator keys
+  hosts: validator
+  gather_facts: false
+  serial: 20
+  vars:
+    output_keys_dirpath: /tmp/generated_keys/validator
+    output_keys_dirpath_cont: /validator_prep/validator
+    output_keys_dirpath_volume: /tmp/generated_keys:/validator_prep
+  tasks:
+    - name: Parse indexes range
+      set_fact:
+        from_index: "{{ indexes.split('..')[0] | int }}"
+        to_index: "{{ indexes.split('..')[1] | int }}"
+
+    - name: Clear directory
+      become: true
+      shell: rm -rf {{output_keys_dirpath}}
+
+    - name: Generate keys
+      shell: >
+        docker run --rm --entrypoint=eth2-val-tools \
+        -v {{output_keys_dirpath_volume}} \
+        skylenet/ethereum-genesis-generator keystores \
+        --insecure \
+        --prysm-pass="prysm" \
+        --out-loc="{{output_keys_dirpath_cont}}" \
+        --source-max={{from_index}} \
+        --source-min={{to_index}} \
+        --source-mnemonic="{{mnemonic}}"
+    # Grab the right keys for each eth2 client
+    - name: Copy keys for lighthouse
+      when: eth2_client_name == 'lighthouse'
+      shell: |
+        cp -r "{{output_keys_dirpath}}/keys" "{{validator_node_dir}}/validators"
+        cp -r "{{output_keys_dirpath}}/secrets" "{{validator_node_dir}}/secrets"
+    - name: Copy keys for teku
+      when: eth2_client_name == 'teku'
+      shell: |
+        cp -r "{{output_keys_dirpath}}/teku-keys" "{{validator_node_dir}}/keys"
+        cp -r "{{output_keys_dirpath}}/teku-secrets" "{{validator_node_dir}}/secrets"
+    - name: Create folders for prysm
+      when: eth2_client_name == 'prysm'
+      shell: |
+        mkdir -p "{{validator_node_dir}}/wallet/direct/accounts"
+        echo "prysm" > "{{validator_node_dir}}/wallet_pass.txt"
+        cp -r "{{output_keys_dirpath}}/prysm/direct/accounts/all-accounts.keystore.json" "{{validator_node_dir}}/wallet/direct/accounts/all-accounts.keystore.json"
+        cp -r "{{output_keys_dirpath}}/prysm/keymanageropts.json" "{{validator_node_dir}}/wallet/direct/keymanageropts.json"
+    - name: Copy keys for nimbus
+      when: eth2_client_name == 'nimbus'
+      shell: |
+        cp -r "{{output_keys_dirpath}}/nimbus-keys" "{{validator_node_dir}}/keys"
+        cp -r "{{output_keys_dirpath}}/secrets" "{{validator_node_dir}}/secrets"
+    - name: Copy keys for lodestar
+      when: eth2_client_name == 'lodestar'
+      shell: |
+        cp -r "{{output_keys_dirpath}}/keys" "{{validator_node_dir}}/keystores"
+        cp -r "{{output_keys_dirpath}}/secrets" "{{validator_node_dir}}/secrets"
+    - name: Modify permissions to match user-group inside docker image
+      shell: chown -R "{{validator_user_id}}" "{{validator_node_dir}}"
+      become: true

--- a/playbooks/tasks/generate_eth2_genesis_and_keys.yml
+++ b/playbooks/tasks/generate_eth2_genesis_and_keys.yml
@@ -36,6 +36,7 @@
         --mnemonics /data/mnemonics.yaml \
         --tranches-dir /data/tranches \
         --state-output /data/genesis.ssz
+
 - name: Generate validator keys
   hosts: validator
   gather_facts: false

--- a/playbooks/tasks/scripts/validate_eth2_indexes.py
+++ b/playbooks/tasks/scripts/validate_eth2_indexes.py
@@ -1,0 +1,77 @@
+#!/usr/bin/python
+
+import sys
+import json
+import yaml
+import time
+
+# Expect YAML or JSON first arg with a dict of keysdata by hostname
+# ```
+# devnet-2-lighthouse-nethermind-1:
+#   indexes: 0000..1000
+#   mnemonic: giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete
+# devnet-2-lighthouse-nethermind-2:
+#   indexes: 1000..2000
+#   mnemonic: giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete
+# ```
+host_keysdata_str = sys.argv[1]
+host_keysdata = yaml.load(host_keysdata_str)
+
+# Expects as second and third arguments the paths of config.yaml, mnemonics.yaml
+# ```
+# /custom_config_data
+#   config.yaml
+#   mnemonics.yaml
+# ```
+eth2_config_filepath = sys.argv[2]
+mnemonics_out_filepath = sys.argv[3]
+
+
+total_count = 0
+count_by_mnemonic = {}
+
+for hostname in host_keysdata:
+  keysdata = host_keysdata[hostname]
+  indexes = keysdata['indexes']
+  mnemonic = keysdata['mnemonic']
+  # 0000..1000
+  from_index = int(indexes.split("..")[0])
+  to_index = int(indexes.split("..")[1])
+  count = to_index - from_index
+
+  # Validate all ranges are ascending
+  if to_index < from_index:
+    raise Exception("{0} indexes value {1} is not ascending".format(hostname, indexes))
+
+  # Validate all ranges are contiguous
+  prev_count = count_by_mnemonic.get(mnemonic, 0)
+  if prev_count != from_index:
+    raise Exception("{0} range not contiguous: prev_count {1} from_index {2}".format(hostname, prev_count, from_index))
+
+  count_by_mnemonic[mnemonic] = prev_count + count
+  total_count = total_count + count
+
+
+# Ensure config.yaml has correct validator count
+eth2_config_file = open(eth2_config_filepath, mode='r')
+eth2_config_yaml = yaml.load(eth2_config_file.read())
+eth2_config_file.close()
+
+min_validator_count = eth2_config_yaml['MIN_GENESIS_ACTIVE_VALIDATOR_COUNT']
+expected_genesis_time = eth2_config_yaml['MIN_GENESIS_TIME'] + eth2_config_yaml['GENESIS_DELAY']
+
+if total_count < min_validator_count:
+  raise Exception("total_count {0} < MIN_GENESIS_ACTIVE_VALIDATOR_COUNT {1}".format(total_count, min_validator_count))
+
+if expected_genesis_time < time.time():
+  raise Exception("MIN_GENESIS_TIME + GENESIS_DELAY {0} is in the past".format(expected_genesis_time))
+
+# Format `mnemonics.yml`
+# ```yaml
+# - mnemonic: "giant issue aisle success illegal bike spike question tent bar rely arctic volcano long crawl hungry vocal artwork sniff fantasy very lucky have athlete"
+#   count: 11000
+# ```
+mnemonics = list(map(lambda kv: {'mnemonic':kv[0], 'count':kv[1]}, count_by_mnemonic.items()))
+mnemonics_file = open(mnemonics_out_filepath, "w")
+mnemonics_file.write(yaml.dump(mnemonics))
+mnemonics_file.close()


### PR DESCRIPTION
Current way to create genesis and keys is error-prone and could be de-duplicated across deployments.

This PR makes the scripts `generate_genesis.sh` and `generate_keys.sh` part of a playbook. The only info you need to provide is the count of keys + mnemonic for each validator host in `inventory.ini`. Example below:

```
merge-devnet-2-lighthouse-nethermind-1  ansible_host=137.184.125.112 mnemonic={{mnemonic_0}} indexes=0000..1000
merge-devnet-2-lighthouse-nethermind-2  ansible_host=164.92.80.84 mnemonic={{mnemonic_0}} indexes=1000..2000
merge-devnet-2-lighthouse-nethermind-3  ansible_host=164.92.70.59 mnemonic={{mnemonic_0}} indexes=2000..3000
merge-devnet-2-lighthouse-nethermind-4  ansible_host=164.92.79.74 mnemonic={{mnemonic_0}} indexes=3000..4000
merge-devnet-2-prysm-nethermind-1  ansible_host=143.198.100.35 mnemonic={{mnemonic_0}} indexes=4000..5000
merge-devnet-2-prysm-nethermind-2  ansible_host=178.128.227.39 mnemonic={{mnemonic_0}} indexes=5000..6000
merge-devnet-2-prysm-nethermind-3  ansible_host=178.128.237.215 mnemonic={{mnemonic_0}} indexes=6000..7000
merge-devnet-2-prysm-nethermind-4  ansible_host=165.22.49.121 mnemonic={{mnemonic_0}} indexes=7000..8000
merge-devnet-2-lodestar-nethermind-1  ansible_host=165.22.49.26 mnemonic={{mnemonic_0}} indexes=8000..9000
merge-devnet-2-lodestar-nethermind-2  ansible_host=134.209.86.164 mnemonic={{mnemonic_0}} indexes=9000..10000
merge-devnet-2-teku-nethermind-1  ansible_host=134.209.86.113 mnemonic={{mnemonic_0}} indexes=10000..11000
```
Then in a hidden `secrets.yml` vars (or some other strategy) you define the mnemonics

The playbook and scripts figure out automatically:
- count of keys per mnemonic for genesis generation
- asserts ranges are ascending and contiguous
- parses range to call keystore generation
- keystore generation is done directly in the hosts, which speeds it up significantly since it's parallelized now + no need to archive and upload