### PR TITLE
Fix typo in range at generate_eth2_genesis_and_keys

### DIFF
--- a/playbooks/tasks/generate_eth2_genesis_and_keys.yml
+++ b/playbooks/tasks/generate_eth2_genesis_and_keys.yml
@@ -63,8 +63,8 @@
         --insecure \
         --prysm-pass="prysm" \
         --out-loc="{{output_keys_dirpath_cont}}" \
-        --source-max={{from_index}} \
-        --source-min={{to_index}} \
+        --source-max={{to_index}} \
+        --source-min={{from_index}} \
         --source-mnemonic="{{mnemonic}}"
     # Grab the right keys for each eth2 client
     - name: Copy keys for lighthouse


### PR DESCRIPTION
- Typo introduced in https://github.com/parithosh/consensus-deployment-ansible/pull/66