### PR TITLE
Add create_bootstrap_user_first_run

### DIFF
--- a/playbooks/deploy_devnet_from_scratch.yml
+++ b/playbooks/deploy_devnet_from_scratch.yml
@@ -1,0 +1,19 @@
+- import_playbook: tasks/create_bootstrap_user_first_run.yml
+
+# Setup hosts from scatch
+- import_playbook: tasks/setup_machine.yml
+- import_playbook: tasks/start_firewall.yml
+
+# Generate eth2 genesis + keys on remote host
+- import_playbook: tasks/generate_eth2_genesis_and_keys.yml
+# Upload custom config data
+- import_playbook: tasks/upload_custom_config_data.yml
+
+# Run all containers
+- import_playbook: setup_execution_and_consensus_full.yml
+- import_playbook: tasks/start_txfuzz.yml
+- import_playbook: tasks/setup_test_sync_cron.yml
+- import_playbook: setup_beacon_and_execution_explorer_full.yml
+#
+# TODO:
+# - Update bootnodes and restart containers

--- a/playbooks/tasks/create_bootstrap_user.yml
+++ b/playbooks/tasks/create_bootstrap_user.yml
@@ -39,35 +39,6 @@
         regexp: "^%{{ bootstrap_user }}"
         line: "%{{ bootstrap_user }} ALL=(ALL) NOPASSWD: ALL"
 
-- name: Run bootstrap playbook to ensure basic stuff works and add oh-my-zsh
-  hosts: all
-  remote_user: "{{ bootstrap_user }}"
-  gather_facts: true
-  become: true
-  roles:
-    # Prepare system to be managed by Ansible.
-    - role: robertdebock.bootstrap
-      tags: [bootstrap]
-    - role: robertdebock.fail2ban
-      tags: [ fail2ban ]
-      vars:
-        - fail2ban_loglevel: INFO
-        - fail2ban_logtarget: /var/log/fail2ban.log
-        - fail2ban_maxretry: 10
-        - fail2ban_bantime: 6000
-    - role: gantsign.oh-my-zsh
-      users:
-        - username: "{{ bootstrap_user }}"
-          theme: powerlevel9k/powerlevel9
-  tasks:
-    - name: Set custom .zshrc config
-      lineinfile:
-        dest: "/home/{{ bootstrap_user }}/.zshrc"
-        state: present
-        regexp: "^{{ item.key }}="
-        line: "{{ item.key }}=\"{{ item.value }}\""
-      loop: "{{ oh_my_zsh_config | dict2items }}"
-
 - name: Log in as new user to disable root
   hosts: all
   user: "{{ bootstrap_user }}"

--- a/playbooks/tasks/create_bootstrap_user_first_run.yml
+++ b/playbooks/tasks/create_bootstrap_user_first_run.yml
@@ -1,0 +1,23 @@
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Set ansible_ssh_user to root
+      set_fact:
+        ansible_ssh_user: "{{initial_remote_user}}"
+      changed_when: false
+      delegate_to: localhost
+      run_once: true
+# After this playbook: whoami -> root
+
+- import_playbook: create_bootstrap_user.yml
+
+- hosts: all
+  gather_facts: false
+  tasks:
+    - name: Set ansible_ssh_user to bootstrap_user
+      set_fact:
+        ansible_ssh_user: "{{bootstrap_user}}"
+      changed_when: false
+      delegate_to: localhost
+      run_once: true
+# After this playbook: whoami -> devops

--- a/playbooks/tasks/setup_machine.yml
+++ b/playbooks/tasks/setup_machine.yml
@@ -1,18 +1,31 @@
-- name: Setup name and keys
+- name: Run bootstrap playbook to ensure basic stuff works and add oh-my-zsh
   hosts: all
-  become: true
+  remote_user: "{{ bootstrap_user }}"
   gather_facts: true
-  tasks:
-    - name: Add SSH keys from Github users
-      loop: "{{ github_user_pubkeys }}"
-      authorized_key:
-        user: "{{ ansible_user }}"
-        state: present
-        key: "https://github.com/{{ item }}.keys"
+  become: true
   roles:
     # Prepare system to be managed by Ansible.
     - role: robertdebock.bootstrap
       tags: [bootstrap]
+    - role: robertdebock.fail2ban
+      tags: [fail2ban]
+      vars:
+        - fail2ban_loglevel: INFO
+        - fail2ban_logtarget: /var/log/fail2ban.log
+        - fail2ban_maxretry: 10
+        - fail2ban_bantime: 6000
+    - role: gantsign.oh-my-zsh
+      users:
+        - username: "{{ bootstrap_user }}"
+          theme: powerlevel9k/powerlevel9
+  tasks:
+    - name: Set custom .zshrc config
+      lineinfile:
+        dest: "/home/{{ bootstrap_user }}/.zshrc"
+        state: present
+        regexp: "^{{ item.key }}="
+        line: '{{ item.key }}="{{ item.value }}"'
+      loop: "{{ oh_my_zsh_config | dict2items }}"
 
 - import_playbook: setup_hostname.yml
 
@@ -20,7 +33,7 @@
   hosts:
     - all
   become: true
-  gather_facts: true  # Needed to check if 'ansible_distribution_release' is 'bionic'
+  gather_facts: true # Needed to check if 'ansible_distribution_release' is 'bionic'
   tasks:
     - name: Ubuntu universe repo and update
       block:


### PR DESCRIPTION
Current playbooks have bad UX for first run since initial user is almost always `root` while we want to run off `devops`.

This PR uses 
```
      set_fact:
        ansible_ssh_user: ...
```

To dynamically change the ssh user and allow to deploy in one run instead of two, and not have to edit `all.yaml`.

@parithosh I've moved some actions from `create_bootstrap_user` to `setup_machine` to allow to wrap it with `create_bootstrap_user_first_run`. I think actions are in more convenient place, and should make no difference in normal ops.

